### PR TITLE
Allow to use a different texture target on video textures on Android

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.code.style=official
 group=com.soywiz.korlibs.korvi
 version=0.2.4-SNAPSHOT
 
-korimVersion=1.12.26
+korimVersion=1.12.28
 korauVersion=1.11.9
 
 jcodecVersion=0.2.5

--- a/korvi/src/androidMain/kotlin/com/soywiz/korvi/internal/KorviVideoAndroidMediaPlayer.kt
+++ b/korvi/src/androidMain/kotlin/com/soywiz/korvi/internal/KorviVideoAndroidMediaPlayer.kt
@@ -121,8 +121,11 @@ class SurfaceNativeImage(width: Int, height: Int, val info: SurfaceTextureInfo) 
     val surfaceTexture get() = info.texture
 
     override val forcedTexId: Int get() = info.texId
+    override val forcedTexTarget: Int get() = GL_TEXTURE_EXTERNAL_OES
 
     companion object {
+        const val GL_TEXTURE_EXTERNAL_OES = 0x8D65
+
         operator fun invoke(width: Int, height: Int): SurfaceNativeImage {
             val info = createSurfacePair()
             return SurfaceNativeImage(width, height, info)


### PR DESCRIPTION
Some work on https://github.com/korlibs/korvi/issues/4

Depends on korim `1.12.28` deploy: https://github.com/korlibs/korim/actions/runs/159680257